### PR TITLE
fix: lazy check ethereum on window

### DIFF
--- a/packages/wallet-connector-evm/package.json
+++ b/packages/wallet-connector-evm/package.json
@@ -18,7 +18,7 @@
 		"build:resources": "tsx generatePredicateResources.ts",
 		"build": "run-s build:resources && tsc && vite build",
 		"fmt": "prettier --config .prettierrc 'src/*.ts' 'test/*.ts' --write",
-		"test": "run-s build:resources && mocha --require ts-node/register  test/*.test.ts"
+		"test": "run-s build:resources && mocha --require ts-node/register test/*.test.ts"
 	},
 	"dependencies": {
 		"@ethereumjs/util": "^9.0.1",


### PR DESCRIPTION
Create a lazy get ethereum provider to avoid cases were at the moment of instantiation of the Connector the ethereum object is not available, on this PR we use a arbitrary timeout of 500 milliseconds, what can lead to issues if the MetaMask takes more than this to inject the code on the window.